### PR TITLE
fix ultrathink prompt wording

### DIFF
--- a/bin/claudefsd-dev
+++ b/bin/claudefsd-dev
@@ -145,7 +145,8 @@ Do not include any additional commentary or explanations outside of these tagged
 
     # run the static code reviewer using Claude Code with ultrathink (replaces codex o3)
     # run it in the background because it's thorough
-    (claude --dangerously-skip-permissions --ultrathink -p "
+    (claude --dangerously-skip-permissions -p "Make sure you ultrathink about this
+
 You are the team's static code reviewer.
 A developer has completed this task: $nexttask
 The developer's notes are at $LOGFILE-developer .

--- a/bin/claudefsd-plan
+++ b/bin/claudefsd-plan
@@ -60,7 +60,9 @@ echo "Running claude..."
 claude --dangerously-skip-permissions -p "$prompt1" | tee >(cat > $LOGFILE-ba1)
 
 echo "Running claude with ultrathink (results won't display)..."
-claude --dangerously-skip-permissions --ultrathink -p "$prompt1" > $LOGFILE-ba2
+claude --dangerously-skip-permissions -p "Make sure you ultrathink about this
+
+$prompt1" > $LOGFILE-ba2
 
 echo -e "\033[32m==================================================================\033[0m"
 echo -e "\033[32m== ANSWER THE QUESTIONS IN QUESTIONS.md\033[0m"

--- a/bin/claudefsd-plan-gen
+++ b/bin/claudefsd-plan-gen
@@ -56,7 +56,9 @@ echo "Running claude..."
 claude --dangerously-skip-permissions -p "$prompt2" | tee >(cat > $LOGFILE-ba3-$round)
 
 echo "Running claude with ultrathink (results won't display)..."
-claude --dangerously-skip-permissions --ultrathink -p "$prompt2" > $LOGFILE-ba4-$round
+claude --dangerously-skip-permissions -p "Make sure you ultrathink about this
+
+$prompt2" > $LOGFILE-ba4-$round
 
 echo -e "\033[32m==================================================================\033[0m"
 echo -e "\033[32m== DONE\033[0m"


### PR DESCRIPTION
## Summary
- remove unsupported `--ultrathink` option from helper scripts
- inline ultrathink reminder text into Claude prompts

## Testing
- `npm test` *(fails: Missing script)*